### PR TITLE
Feature/add unit tests

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="-1088286143">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="28629151">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="163438969">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,6 +13,39 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
+      <SelectionState runConfigName="AuthHomeFlowTest">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2026-04-16T04:26:49.249351Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/italonovoa/.android/avd/Medium_Phone.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
+      </SelectionState>
+      <SelectionState runConfigName="All Tests">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2026-04-16T04:26:49.249351Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/italonovoa/.android/avd/Medium_Phone.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
+      </SelectionState>
+      <SelectionState runConfigName="MainActivity">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2026-04-16T04:26:49.249351Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/italonovoa/.android/avd/Medium_Phone.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,6 +13,7 @@ android {
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildFeatures {
@@ -60,6 +61,17 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
     implementation("com.google.android.material:material:1.12.0")
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test:runner:1.6.2")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+
     debugImplementation(libs.androidx.compose.ui.tooling)
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,9 +65,9 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
 
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test:runner:1.6.2")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test:runner:1.7.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 

--- a/app/src/androidTest/kotlin/com/misw4203/vinilos/app/AuthHomeFlowTest.kt
+++ b/app/src/androidTest/kotlin/com/misw4203/vinilos/app/AuthHomeFlowTest.kt
@@ -1,0 +1,72 @@
+package com.misw4203.vinilos.app
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class AuthHomeFlowTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun authScreen_displaysMainOptions() {
+        waitForText("Select Your Profile")
+
+        composeRule.onNodeWithText("Visitor").assertIsDisplayed()
+        composeRule.onNodeWithText("Collector").assertIsDisplayed()
+        composeRule.onNodeWithText("Get Started").assertIsDisplayed()
+    }
+
+    @Test
+    fun selectingVisitor_navigatesToHome() {
+        waitForText("Select Your Profile")
+
+        composeRule.onNodeWithText("Visitor").performClick()
+        Espresso.onIdle()
+
+        waitForText("Vinilos")
+        composeRule.onNodeWithText("Albums").assertIsDisplayed()
+    }
+
+    @Test
+    fun homeBackButton_returnsToAuth() {
+        waitForText("Select Your Profile")
+
+        composeRule.onNodeWithText("Visitor").performClick()
+        Espresso.onIdle()
+        waitForText("Vinilos")
+
+        waitForBackButton()
+        composeRule.onNodeWithContentDescription("Back").performClick()
+        Espresso.onIdle()
+
+        waitForText("Select Your Profile")
+        composeRule.onNodeWithText("Get Started").assertIsDisplayed()
+    }
+
+    private fun waitForText(text: String) {
+        composeRule.waitUntil(timeoutMillis = 10_000) {
+            composeRule.onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun waitForBackButton() {
+        composeRule.waitUntil(timeoutMillis = 10_000) {
+            composeRule.onAllNodesWithContentDescription("Back").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+}
+

--- a/app/src/androidTest/kotlin/com/misw4203/vinilos/app/AuthHomeFlowTest.kt
+++ b/app/src/androidTest/kotlin/com/misw4203/vinilos/app/AuthHomeFlowTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import org.junit.Rule
@@ -35,10 +34,11 @@ class AuthHomeFlowTest {
         waitForText("Select Your Profile")
 
         composeRule.onNodeWithText("Visitor").performClick()
-        Espresso.onIdle()
+        composeRule.waitForIdle()
+        continueFromAuthIfNeeded()
 
         waitForText("Vinilos")
-        composeRule.onNodeWithText("Albums").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Back").assertIsDisplayed()
     }
 
     @Test
@@ -46,12 +46,12 @@ class AuthHomeFlowTest {
         waitForText("Select Your Profile")
 
         composeRule.onNodeWithText("Visitor").performClick()
-        Espresso.onIdle()
+        composeRule.waitForIdle()
         waitForText("Vinilos")
 
         waitForBackButton()
         composeRule.onNodeWithContentDescription("Back").performClick()
-        Espresso.onIdle()
+        composeRule.waitForIdle()
 
         waitForText("Select Your Profile")
         composeRule.onNodeWithText("Get Started").assertIsDisplayed()
@@ -66,6 +66,14 @@ class AuthHomeFlowTest {
     private fun waitForBackButton() {
         composeRule.waitUntil(timeoutMillis = 10_000) {
             composeRule.onAllNodesWithContentDescription("Back").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun continueFromAuthIfNeeded() {
+        val getStartedNodes = composeRule.onAllNodesWithText("Get Started").fetchSemanticsNodes()
+        if (getStartedNodes.isNotEmpty()) {
+            composeRule.onNodeWithText("Get Started").performClick()
+            composeRule.waitForIdle()
         }
     }
 }

--- a/app/src/main/kotlin/com/misw4203/vinilos/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/misw4203/vinilos/app/MainActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 
-class nchMainActivity : ComponentActivity() {
+class MainActivity : ComponentActivity() {
     private val appContainer by lazy { AppContainer() }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/com/misw4203/vinilos/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/misw4203/vinilos/app/MainActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 
-class MainActivity : ComponentActivity() {
+class nchMainActivity : ComponentActivity() {
     private val appContainer by lazy { AppContainer() }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/feature-auth/build.gradle.kts
+++ b/feature-auth/build.gradle.kts
@@ -49,5 +49,9 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.kotlinx.coroutines.android)
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+
     debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/feature-auth/src/test/kotlin/com/misw4203/vinilos/feature/auth/ui/AuthViewModelTest.kt
+++ b/feature-auth/src/test/kotlin/com/misw4203/vinilos/feature/auth/ui/AuthViewModelTest.kt
@@ -1,0 +1,138 @@
+package com.misw4203.vinilos.feature.auth.ui
+
+import com.misw4203.vinilos.core.utils.model.RolePermissions
+import com.misw4203.vinilos.core.utils.model.UserRole
+import com.misw4203.vinilos.core.utils.model.UserSession
+import com.misw4203.vinilos.core.utils.repository.SessionRepository
+import com.misw4203.vinilos.feature.auth.domain.SelectRoleUseCase
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule: TestWatcher = MainDispatcherRule()
+
+    @Test
+    fun onRoleSelected_updatesState() = runTest {
+        val repository = FakeSessionRepository()
+        val viewModel = AuthViewModel(SelectRoleUseCase(repository))
+
+        viewModel.onRoleSelected(UserRole.VISITOR)
+
+        assertEquals(UserRole.VISITOR, viewModel.uiState.value.selectedRole)
+        assertTrue(viewModel.uiState.value.canContinue)
+    }
+
+    @Test
+    fun onGetStarted_withoutRole_doesNothing() = runTest {
+        val repository = FakeSessionRepository()
+        val viewModel = AuthViewModel(SelectRoleUseCase(repository))
+
+        viewModel.onGetStarted()
+        advanceUntilIdle()
+
+        assertTrue(repository.savedRoles.isEmpty())
+        assertNull(repository.session.value)
+    }
+
+    @Test
+    fun onGetStarted_withRole_savesRoleAndEmitsNavigateHome() = runTest {
+        val repository = FakeSessionRepository()
+        val viewModel = AuthViewModel(SelectRoleUseCase(repository))
+        val effectDeferred = async { viewModel.effects.first() }
+
+        viewModel.onRoleSelected(UserRole.COLLECTOR)
+        viewModel.onGetStarted()
+        advanceUntilIdle()
+
+        assertEquals(listOf(UserRole.COLLECTOR), repository.savedRoles)
+        assertEquals(AuthUiEffect.NavigateHome, effectDeferred.await())
+        assertFalse(viewModel.uiState.value.isSubmitting)
+    }
+
+    @Test
+    fun onGetStarted_whileSubmitting_ignoresSecondRequest() = runTest {
+        val saveGate = CompletableDeferred<Unit>()
+        val repository = FakeSessionRepository(saveGate = saveGate)
+        val viewModel = AuthViewModel(SelectRoleUseCase(repository))
+
+        viewModel.onRoleSelected(UserRole.COLLECTOR)
+        viewModel.onGetStarted()
+        repository.firstSaveStarted.await()
+
+        assertTrue(viewModel.uiState.value.isSubmitting)
+
+        viewModel.onGetStarted()
+        advanceUntilIdle()
+
+        assertEquals(1, repository.savedRoles.size)
+
+        saveGate.complete(Unit)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.isSubmitting)
+    }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val dispatcher: TestDispatcher = StandardTestDispatcher(),
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}
+
+private class FakeSessionRepository(
+    private val saveGate: CompletableDeferred<Unit>? = null,
+) : SessionRepository {
+
+    val session = MutableStateFlow<UserSession?>(null)
+    val savedRoles = mutableListOf<UserRole>()
+    val firstSaveStarted = CompletableDeferred<Unit>()
+
+    override fun observeSession(): Flow<UserSession?> = session
+
+    override suspend fun saveRole(role: UserRole) {
+        savedRoles += role
+        firstSaveStarted.complete(Unit)
+        saveGate?.await()
+        session.value = UserSession(role = role, permissions = permissionsFor(role))
+    }
+
+    override suspend fun clearSession() {
+        session.value = null
+    }
+
+    private fun permissionsFor(role: UserRole): RolePermissions = when (role) {
+        UserRole.VISITOR -> RolePermissions(canView = true)
+        UserRole.COLLECTOR -> RolePermissions(canView = true, canCreate = true, canEdit = true, canDelete = true)
+    }
+}
+

--- a/feature-home/build.gradle.kts
+++ b/feature-home/build.gradle.kts
@@ -49,6 +49,10 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.kotlinx.coroutines.android)
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+
     debugImplementation(libs.androidx.compose.ui.tooling)
 }
 

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/HomeUiState.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/HomeUiState.kt
@@ -29,8 +29,12 @@ data class HomeUiState(
     val filteredItems: List<HomeItem>
         get() = when (selectedFilter) {
             HomeFilter.RECENTLY_ADDED -> items.sortedByDescending(HomeItem::year)
-            HomeFilter.ROCK -> items.filter { it.genre.equals("Rock", ignoreCase = true) }
-            HomeFilter.JAZZ -> items.filter { it.genre.equals("Jazz", ignoreCase = true) }
+            HomeFilter.ROCK -> items
+                .filter { it.genre.equals("Rock", ignoreCase = true) }
+                .sortedByDescending(HomeItem::year)
+            HomeFilter.JAZZ -> items
+                .filter { it.genre.equals("Jazz", ignoreCase = true) }
+                .sortedByDescending(HomeItem::year)
         }
 
     val featuredItem: HomeItem?

--- a/feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/ui/HomeViewModelTest.kt
+++ b/feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/ui/HomeViewModelTest.kt
@@ -1,0 +1,184 @@
+package com.misw4203.vinilos.feature.home.ui
+
+import com.misw4203.vinilos.core.utils.model.RolePermissions
+import com.misw4203.vinilos.core.utils.model.UserRole
+import com.misw4203.vinilos.core.utils.model.UserSession
+import com.misw4203.vinilos.core.utils.repository.SessionRepository
+import com.misw4203.vinilos.core.utils.usecase.ClearSessionUseCase
+import com.misw4203.vinilos.core.utils.usecase.ObserveSessionUseCase
+import com.misw4203.vinilos.feature.home.domain.model.HomeItem
+import com.misw4203.vinilos.feature.home.domain.repository.HomeRepository
+import com.misw4203.vinilos.feature.home.domain.usecase.ObserveHomeItemsUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule: TestWatcher = MainDispatcherRule()
+
+    @Test
+    fun initialState_usesSessionAndItems() = runTest {
+        val sessionRepository = FakeSessionRepository(
+            initialSession = UserSession(
+                role = UserRole.COLLECTOR,
+                permissions = RolePermissions(canView = true, canCreate = true, canEdit = true, canDelete = true),
+            ),
+        )
+        val homeRepository = FakeHomeRepository(sampleItems())
+        val viewModel = buildViewModel(sessionRepository, homeRepository)
+        val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertEquals(UserRole.COLLECTOR, state.session?.role)
+        assertEquals(HomeFilter.RECENTLY_ADDED, state.selectedFilter)
+        assertEquals("Newest", state.featuredItem?.title)
+        assertEquals(3, state.totalCount)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun onFilterSelected_appliesGenreFilter() = runTest {
+        val sessionRepository = FakeSessionRepository()
+        val homeRepository = FakeHomeRepository(sampleItems())
+        val viewModel = buildViewModel(sessionRepository, homeRepository)
+        val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
+
+        viewModel.onFilterSelected(HomeFilter.ROCK)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(HomeFilter.ROCK, state.selectedFilter)
+        assertEquals(2, state.totalCount)
+        assertEquals("Newest", state.featuredItem?.title)
+        assertEquals(1, state.gridItems.size)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun onTabSelected_updatesSelectedTab() = runTest {
+        val viewModel = buildViewModel(FakeSessionRepository(), FakeHomeRepository(sampleItems()))
+        val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
+
+        viewModel.onTabSelected(HomeTab.ARTISTS)
+        advanceUntilIdle()
+
+        assertEquals(HomeTab.ARTISTS, viewModel.uiState.value.selectedTab)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun onChangeProfile_clearsSessionAndEmitsNavigateAuth() = runTest {
+        val sessionRepository = FakeSessionRepository(
+            initialSession = UserSession(UserRole.VISITOR, RolePermissions(canView = true)),
+        )
+        val viewModel = buildViewModel(sessionRepository, FakeHomeRepository(sampleItems()))
+        val collectStateJob = backgroundScope.launch { viewModel.uiState.collect { } }
+        val effectDeferred = async { viewModel.effects.first() }
+
+        viewModel.onChangeProfile()
+        advanceUntilIdle()
+
+        assertNull(sessionRepository.session.value)
+        assertEquals(1, sessionRepository.clearCalls)
+        assertEquals(HomeUiEffect.NavigateAuth, effectDeferred.await())
+
+        collectStateJob.cancel()
+    }
+
+    @Test
+    fun onSearchClick_emitsMessageEffect() = runTest {
+        val viewModel = buildViewModel(FakeSessionRepository(), FakeHomeRepository(sampleItems()))
+        val effectDeferred = async { viewModel.effects.first() }
+
+        viewModel.onSearchClick()
+        advanceUntilIdle()
+
+        assertEquals(HomeUiEffect.ShowMessage("Search coming soon"), effectDeferred.await())
+    }
+
+    private fun buildViewModel(
+        sessionRepository: FakeSessionRepository,
+        homeRepository: FakeHomeRepository,
+    ): HomeViewModel {
+        return HomeViewModel(
+            observeSessionUseCase = ObserveSessionUseCase(sessionRepository),
+            observeHomeItemsUseCase = ObserveHomeItemsUseCase(homeRepository),
+            clearSessionUseCase = ClearSessionUseCase(sessionRepository),
+        )
+    }
+
+    private fun sampleItems(): List<HomeItem> = listOf(
+        HomeItem(id = "1", title = "Classic Jazz", artist = "Blue Trio", year = 1998, genre = "Jazz"),
+        HomeItem(id = "2", title = "Old Rock", artist = "Red Stone", year = 1980, genre = "Rock"),
+        HomeItem(id = "3", title = "Newest", artist = "Future Band", year = 2024, genre = "Rock"),
+    )
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+private class MainDispatcherRule(
+    private val dispatcher: TestDispatcher = StandardTestDispatcher(),
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}
+
+private class FakeSessionRepository(
+    initialSession: UserSession? = null,
+) : SessionRepository {
+
+    val session = MutableStateFlow(initialSession)
+    var clearCalls: Int = 0
+
+    override fun observeSession(): Flow<UserSession?> = session
+
+    override suspend fun saveRole(role: UserRole) {
+        session.value = UserSession(role = role, permissions = RolePermissions(canView = true))
+    }
+
+    override suspend fun clearSession() {
+        clearCalls += 1
+        session.value = null
+    }
+}
+
+private class FakeHomeRepository(
+    items: List<HomeItem>,
+) : HomeRepository {
+
+    private val data = MutableStateFlow(items)
+
+    override fun observeItems(): Flow<List<HomeItem>> = data
+}
+


### PR DESCRIPTION
This pull request introduces comprehensive test coverage for both the authentication and home modules, improves test dependencies, and refines the home UI's filtering logic. The most important changes are summarized below.

---

**Automated Testing:**

* Added a new UI test `AuthHomeFlowTest` to `app/src/androidTest/kotlin/com/misw4203/vinilos/app/`, covering profile selection, navigation to home, and back navigation to authentication. (`[app/src/androidTest/kotlin/com/misw4203/vinilos/app/AuthHomeFlowTest.ktR1-R80](diffhunk://#diff-8891ae80c036820059dbab679cfc9c2810b566a26d4ccc1501c34d6f42e0f8f8R1-R80)`)
* Added unit tests for `AuthViewModel` in `feature-auth`, verifying role selection, session saving, and effect emission. (`[feature-auth/src/test/kotlin/com/misw4203/vinilos/feature/auth/ui/AuthViewModelTest.ktR1-R138](diffhunk://#diff-dc71e37befe37e1e5d071afc9c170d62942ad61c8e147258cea931d6763d1a92R1-R138)`)
* Added unit tests for `HomeViewModel` in `feature-home`, testing session usage, filter application, tab selection, profile change, and UI effects. (`[feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/ui/HomeViewModelTest.ktR1-R184](diffhunk://#diff-f229c1633310685b248fea015b2e765bc7766cbaafdf43b37c910b5738847eb9R1-R184)`)

**Test Dependencies and Configuration:**

* Updated `app/build.gradle.kts`, `feature-auth/build.gradle.kts`, and `feature-home/build.gradle.kts` to include necessary dependencies for unit and instrumentation testing, such as JUnit, coroutines test, and AndroidX test libraries. (`[[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R64-R75)`, `[[2]](diffhunk://#diff-387e23c4a797bf567c13be2defca5903d2aee1de8213c5d40aa8b2884177a719R52-R55)`, `[[3]](diffhunk://#diff-85b14d654222e45156762605bb9b9af2664205b972c7baa53a80e1d4a7541eeaR52-R55)`)
* Set the `testInstrumentationRunner` to `androidx.test.runner.AndroidJUnitRunner` in `app/build.gradle.kts` to enable instrumentation tests. (`[app/build.gradle.ktsR16](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R16)`)

**Home UI Filtering Logic:**

* Updated `HomeUiState` in `feature-home` so that genre-based filters (`ROCK`, `JAZZ`) now return items sorted by descending year, improving the user experience when filtering home items. (`[feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/HomeUiState.ktL32-R37](diffhunk://#diff-c171b8f37da514bf8591ae02dad12dd441ad92ff5b89a4c1020b83295524ed5cL32-R37)`)

**IDE and Emulator Configuration:**

* Added `.idea/androidTestResultsUserPreferences.xml` and updated `.idea/deploymentTargetSelector.xml` to persist Android test results UI preferences and emulator selection for common run configurations. (`[[1]](diffhunk://#diff-a3cca549dc9c571f58c2a2884a7368a3325761a2ffae041d68d543008b77a8f7R1-R48)`, `[[2]](diffhunk://#diff-48ade0dcc88e13ad2f209104182451574719123469c44aa4bb0558302d2ee7fbR16-R48)`)