### PR TITLE
Feature/reduce memory

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-05-02T21:34:25.672897Z">
+        <DropdownSelection timestamp="2026-05-07T03:03:32.683954Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/italo/.android/avd/Medium_Phone.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=geh6eyof8tmvv485" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/AlbumDetailScreen.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/AlbumDetailScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -124,7 +125,15 @@ fun AlbumDetailScreen(
 
 @Composable
 private fun DetailHeroCard(album: HomeItem) {
-    val brush = editorialRadialBrush(seed = "${album.id}${album.title}${album.artist}${album.genre}")
+    val brush = remember(album.id) { editorialRadialBrush(seed = "${album.id}${album.title}${album.artist}${album.genre}") }
+    val overlayBrush = remember {
+        Brush.verticalGradient(
+            colors = listOf(
+                Color.Transparent,
+                Color.Black.copy(alpha = 0.62f),
+            ),
+        )
+    }
 
     Card(
         shape = RoundedCornerShape(32.dp),
@@ -155,14 +164,7 @@ private fun DetailHeroCard(album: HomeItem) {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(
-                            Brush.verticalGradient(
-                                colors = listOf(
-                                    Color.Transparent,
-                                    Color.Black.copy(alpha = 0.62f),
-                                ),
-                            ),
-                        ),
+                        .background(overlayBrush),
                 )
 
                 Box(

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/ArtistsScreen.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/ArtistsScreen.kt
@@ -92,11 +92,16 @@ fun ArtistsScreen(
                         )
                     }
                 }
-                items(state.artists.drop(1), key = { it.id }) { artist ->
-                    ArtistListItem(
-                        artist = artist,
-                        onClick = { onArtistClick(artist) },
-                    )
+                items(
+                    items = state.artists,
+                    key = { it.id }
+                ) { artist ->
+                    if (artist.id != state.artists.firstOrNull()?.id) {
+                        ArtistListItem(
+                            artist = artist,
+                            onClick = { onArtistClick(artist) },
+                        )
+                    }
                 }
             }
         }
@@ -252,7 +257,7 @@ private fun FeaturedArtistCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val brush = editorialBrush(seed = "${artist.id}${artist.name}")
+    val brush = remember(artist.id, artist.name) { editorialBrush(seed = "${artist.id}${artist.name}") }
     Card(
         modifier = modifier
             .fillMaxWidth()
@@ -315,7 +320,7 @@ private fun ArtistListItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val brush = editorialBrush(seed = "${artist.id}${artist.name}")
+    val brush = remember(artist.id, artist.name) { editorialBrush(seed = "${artist.id}${artist.name}") }
     Row(
         modifier = modifier
             .fillMaxWidth()

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/ArtistsViewModel.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/ArtistsViewModel.kt
@@ -4,11 +4,15 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.misw4203.vinilos.feature.home.domain.model.Artist
 import com.misw4203.vinilos.feature.home.domain.usecase.ObserveArtistsUseCase
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 data class ArtistsUiState(
     val isLoading: Boolean = true,
@@ -17,19 +21,32 @@ data class ArtistsUiState(
     val query: String = "",
 )
 
+@OptIn(FlowPreview::class)
 class ArtistsViewModel(
     observeArtistsUseCase: ObserveArtistsUseCase,
 ) : ViewModel() {
 
     private val query = MutableStateFlow("")
 
-    val uiState: StateFlow<ArtistsUiState> = combine(observeArtistsUseCase(), query) { all, currentQuery ->
+    private val allArtists = observeArtistsUseCase().distinctUntilChanged()
+
+    private val filteredArtists = combine(
+        allArtists,
+        query.debounce(300).distinctUntilChanged()
+    ) { all, currentQuery ->
         val trimmed = currentQuery.trim()
-        val filtered = if (trimmed.isEmpty()) {
+        if (trimmed.isEmpty()) {
             all
         } else {
             all.filter { it.name.contains(trimmed, ignoreCase = true) }
         }
+    }.distinctUntilChanged()
+
+    val uiState: StateFlow<ArtistsUiState> = combine(
+        allArtists,
+        filteredArtists,
+        query
+    ) { all, filtered, currentQuery ->
         ArtistsUiState(
             isLoading = false,
             artists = filtered,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.2"
+agp = "8.13.2"
 kotlin = "1.9.24"
 ksp = "1.9.24-1.0.20"
 compose-bom = "2024.06.00"


### PR DESCRIPTION
Resumen de Modificaciones y Mejoras
1.
Optimización de Composable Brushes (ArtistsScreen.kt & AlbumDetailScreen.kt):
◦
Modificación: Se envolvió la creación de los objetos Brush (gradientes) en bloques remember.
◦
Mejora: Anteriormente, estos objetos se recreaban en cada recomposición (incluso si los datos no cambiaban), lo que generaba múltiples objetos nativos Shader en memoria. Ahora se reutilizan, reduciendo la presión sobre el recolector de basura (GC) y el consumo de memoria gráfica.
2.
Filtrado de Búsqueda Eficiente (ArtistsViewModel.kt):
◦
Modificación: Se implementó debounce(300ms) y distinctUntilChanged() en el flujo de búsqueda.
◦
Mejora: Esto evita que la aplicación genere múltiples listas filtradas intermedias mientras el usuario escribe rápidamente. Solo se procesa y mantiene en memoria la lista filtrada después de una breve pausa en la escritura, reduciendo drásticamente las asignaciones de memoria temporales.
3.
Iteración de Listas en UI (ArtistsScreen.kt):
◦
Modificación: Se eliminó el uso de .drop(1) en la lista de artistas dentro de LazyColumn.
◦
Mejora: drop(1) crea una copia nueva de la lista en cada recomposición. Ahora se utiliza una lógica de omisión dentro del bloque items, operando directamente sobre la lista original y evitando duplicaciones innecesarias de colecciones en memoria.
4.
Gestión de Ciclo de Vida de Flujos:
◦
Mejora: Se mantiene el uso de SharingStarted.WhileSubscribed(5_000) en los ViewModels. Esto garantiza que si el usuario sale de la pantalla, los recursos y cachés asociados a esos flujos se liberen después de 5 segundos, evitando fugas de memoria en segundo plano.
Análisis del Impacto
•
Impacto en Memoria: La mejora es significativa en escenarios de uso prolongado. Al evitar la creación constante de Shaders y copias de listas, se reduce el "churn" de memoria (asignación/liberación constante), lo que se traduce en una UI más fluida (menos micro-stuttering por GC) y un menor uso de memoria Heap.
•
Impacto en CPU: El debouncing en la búsqueda reduce el uso de CPU al no procesar filtros pesados de texto de forma redundante.
Si bien el consumo actual no parece crítico para un catálogo estándar, estas mejoras previenen que el rendimiento degrade conforme el catálogo de artistas y álbumes crezca. Como paso siguiente, se podría considerar la paginación (Jetpack Paging 3) si la lista de artistas llega a superar los cientos de elementos, para cargar solo lo que es visible en pantalla.