### PR TITLE
fix upload image

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-05-07T03:03:32.683954Z">
+        <DropdownSelection timestamp="2026-05-10T00:25:21.655780Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=geh6eyof8tmvv485" />

--- a/app/src/androidTest/kotlin/com/misw4203/vinilos/app/CreateAlbumNavigationEspressoTest.kt
+++ b/app/src/androidTest/kotlin/com/misw4203/vinilos/app/CreateAlbumNavigationEspressoTest.kt
@@ -47,7 +47,7 @@ class CreateAlbumNavigationEspressoTest {
         composeRule.onAllNodesWithText("Create Album").assertCountEquals(2)
         composeRule.onNodeWithText("Album name").performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithText("Release date").performScrollTo().assertIsDisplayed()
-        composeRule.onNodeWithText("Cover URL").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Choose a cover image").performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithText("Description").performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithText("Choose a genre from the options below").performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithText("Choose a record label from the options below").performScrollTo().assertIsDisplayed()
@@ -84,6 +84,3 @@ class CreateAlbumNavigationEspressoTest {
         composeRule.onAllNodesWithContentDescription("Back").fetchSemanticsNodes()
     }
 }
-
-
-

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/CreateAlbumFormValidation.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/CreateAlbumFormValidation.kt
@@ -14,7 +14,11 @@ internal fun isValidCoverUrl(value: String): Boolean {
 
     return runCatching {
         val uri = URI(trimmed)
-        (uri.scheme == "http" || uri.scheme == "https") && !uri.host.isNullOrBlank()
+        when (uri.scheme) {
+            "http", "https" -> !uri.host.isNullOrBlank()
+            "content", "file" -> !uri.path.isNullOrBlank()
+            else -> false
+        }
     }.getOrDefault(false)
 }
 
@@ -28,8 +32,8 @@ internal fun isValidReleaseDate(value: String): Boolean {
 internal fun isValidDescription(value: String): Boolean = value.trim().length >= MIN_DESCRIPTION_LENGTH
 
 internal fun coverUrlError(value: String): String? = when {
-    value.isBlank() -> "Cover URL is required"
-    !isValidCoverUrl(value) -> "Enter a valid http or https URL"
+    value.isBlank() -> "Cover image is required"
+    !isValidCoverUrl(value) -> "Cover image must be a valid image reference"
     else -> null
 }
 
@@ -71,5 +75,3 @@ internal fun validateCreateAlbumForm(state: CreateAlbumUiState): String? =
         genreError(state.genre),
         recordLabelError(state.recordLabel),
     ).firstOrNull()
-
-

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/CreateAlbumScreen.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/CreateAlbumScreen.kt
@@ -91,7 +91,7 @@ fun CreateAlbumScreen(
     var descriptionTouched by remember { mutableStateOf(false) }
 
     val nameErrorText = if (nameTouched) nameError(state.name) else null
-    val coverUrlErrorText = if (coverTouched) coverUrlError(state.cover) else null
+    val coverErrorText = if (coverTouched) coverUrlError(state.cover) else null
     val releaseDateErrorText = if (releaseDateTouched) releaseDateError(state.releaseDate) else null
     val descriptionErrorText = if (descriptionTouched) descriptionError(state.description) else null
     val formIsValid = validateCreateAlbumForm(state) == null
@@ -184,7 +184,7 @@ fun CreateAlbumScreen(
                                 contract = ActivityResultContracts.GetContent(),
                                 onResult = { uri: Uri? ->
                                     uri?.let { picked ->
-                                        viewModel.onPickImageUri(context.contentResolver, picked)
+                                        viewModel.onPickImageUri(context, picked)
                                     }
                                 },
                             )
@@ -217,7 +217,10 @@ fun CreateAlbumScreen(
                                 modifier = Modifier
                                     .align(Alignment.TopEnd)
                                     .padding(12.dp)
-                                    .clickable { pickImageLauncher.launch("image/*") }
+                                    .clickable {
+                                        coverTouched = true
+                                        pickImageLauncher.launch("image/*")
+                                    }
                                     .semantics { contentDescription = "Choose album cover image" },
                             ) {
                                 Icon(
@@ -269,6 +272,12 @@ fun CreateAlbumScreen(
                                 )
                             }
                         }
+
+                        Text(
+                            text = coverErrorText ?: "Choose a cover image (we'll crop to square and optimize quality)",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = if (coverErrorText != null) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
 
                         SectionLabel(text = "Album details")
 
@@ -326,17 +335,6 @@ fun CreateAlbumScreen(
                             text = recordLabelError(state.recordLabel) ?: "Select one record label",
                             style = MaterialTheme.typography.labelMedium,
                             color = if (recordLabelError(state.recordLabel) != null) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-
-                        EditorialTextField(
-                            value = state.cover,
-                            onValueChange = viewModel::onCoverChange,
-                            label = "Cover URL",
-                            placeholder = "https://...",
-                            keyboardType = KeyboardType.Uri,
-                            supportingText = if (coverTouched) coverUrlErrorText ?: "Use a valid http or https image URL" else "Paste a valid image URL",
-                            isError = coverUrlErrorText != null,
-                            onTouched = { coverTouched = true },
                         )
 
                         EditorialTextField(
@@ -586,5 +584,3 @@ private fun DatePickerField(
         ),
     )
 }
-
-

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/CreateAlbumViewModel.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/CreateAlbumViewModel.kt
@@ -1,6 +1,8 @@
 package com.misw4203.vinilos.feature.home.ui
 
-import android.content.ContentResolver
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -13,6 +15,9 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.io.File
+import java.io.FileOutputStream
+import kotlin.math.min
 
 data class CreateAlbumUiState(
     val name: String = "",
@@ -48,15 +53,16 @@ class CreateAlbumViewModel(
         _state.value = _state.value.copy(cover = value)
     }
 
-    fun onPickImageUri(contentResolver: ContentResolver, uri: Uri) {
+    fun onPickImageUri(context: Context, uri: Uri) {
         viewModelScope.launch {
             _state.value = _state.value.copy(isSubmitting = true)
-            val uploaded = uploadCoverUseCase(contentResolver, uri.toString())
+            val processedUri = processCoverImage(context, uri)
+            val uploaded = processedUri?.let { uploadCoverUseCase(context.contentResolver, it) }
             _state.value = _state.value.copy(isSubmitting = false)
             if (uploaded != null) {
                 onCoverChange(uploaded)
             } else {
-                _effects.emit(CreateAlbumUiEffect.ShowMessage("Failed to upload cover"))
+                _effects.emit(CreateAlbumUiEffect.ShowMessage("Failed to process cover image"))
             }
         }
     }
@@ -104,5 +110,50 @@ class CreateAlbumViewModel(
             }
         }
     }
-}
 
+    private fun processCoverImage(context: Context, uri: Uri): String? {
+        val resolver = context.contentResolver
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        resolver.openInputStream(uri)?.use { stream ->
+            BitmapFactory.decodeStream(stream, null, options)
+        }
+        if (options.outWidth <= 0 || options.outHeight <= 0) return null
+
+        val maxSize = 1024
+        val sampleSize = calculateSampleSize(options.outWidth, options.outHeight, maxSize)
+        val decodeOptions = BitmapFactory.Options().apply { inSampleSize = sampleSize }
+        val decoded = resolver.openInputStream(uri)?.use { stream ->
+            BitmapFactory.decodeStream(stream, null, decodeOptions)
+        } ?: return null
+
+        val square = centerCropSquare(decoded)
+        val resized = if (square.width > maxSize) {
+            Bitmap.createScaledBitmap(square, maxSize, maxSize, true)
+        } else {
+            square
+        }
+
+        val outputFile = File(context.cacheDir, "cover_${System.currentTimeMillis()}.jpg")
+        FileOutputStream(outputFile).use { out ->
+            resized.compress(Bitmap.CompressFormat.JPEG, 85, out)
+        }
+        return android.net.Uri.fromFile(outputFile).toString()
+    }
+
+    private fun centerCropSquare(source: Bitmap): Bitmap {
+        val size = min(source.width, source.height)
+        val x = (source.width - size) / 2
+        val y = (source.height - size) / 2
+        return Bitmap.createBitmap(source, x, y, size, size)
+    }
+
+    private fun calculateSampleSize(width: Int, height: Int, maxSize: Int): Int {
+        var inSampleSize = 1
+        var halfWidth = width / 2
+        var halfHeight = height / 2
+        while (halfWidth / inSampleSize >= maxSize && halfHeight / inSampleSize >= maxSize) {
+            inSampleSize *= 2
+        }
+        return inSampleSize
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -Djava.net.preferIPv4Stack=true
+org.gradle.java.installations.auto-download=true
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 kotlin.code.style=official

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,14 @@
+
 pluginManagement {
     repositories {
         google()
         mavenCentral()
         gradlePluginPortal()
     }
+}
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
 }
 
 dependencyResolutionManagement {
@@ -21,4 +26,3 @@ include(":core:navigation")
 include(":core:utils")
 include(":feature-auth")
 include(":feature-home")
-


### PR DESCRIPTION
This pull request introduces significant improvements to the album creation feature, focusing on enhancing the user experience for selecting and validating album cover images. It adds support for local image selection, processes images to ensure they are square and optimized, and updates validation and UI messaging accordingly. Additionally, there are minor updates to project configuration files.

**Album Cover Image Selection & Processing:**

* Added support for selecting local images (`content://` or `file://` URIs) as album covers, not just URLs. Selected images are now center-cropped to a square, resized to a maximum of 1024x1024 pixels, and compressed before uploading. (`feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/CreateAlbumViewModel.kt`) [[1]](diffhunk://#diff-a459fce013c3eca3c36685baefbe943e569e817fb5f9a21637fcbf8ee476d093L3-R5) [[2]](diffhunk://#diff-a459fce013c3eca3c36685baefbe943e569e817fb5f9a21637fcbf8ee476d093L51-R65) [[3]](diffhunk://#diff-a459fce013c3eca3c36685baefbe943e569e817fb5f9a21637fcbf8ee476d093R113-R159)
* Updated the validation logic to accept both URLs and local image references for cover images. Error messages and helper texts are now more descriptive and generalized to cover both cases. (`feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/CreateAlbumFormValidation.kt`) [[1]](diffhunk://#diff-008523861c150befc750bb2dc16442bd2f1c04637771c3e43d7d7ba9c1bebae5L17-R21) [[2]](diffhunk://#diff-008523861c150befc750bb2dc16442bd2f1c04637771c3e43d7d7ba9c1bebae5L31-R36)
* Refactored the UI to remove the "Cover URL" text field and replace it with a button for image selection, displaying relevant error or helper text below. (`feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/CreateAlbumScreen.kt`) [[1]](diffhunk://#diff-e0209a3326dbc46514a7f7e75496fe5173eb9d9269eb7f7b714d961d414a2595L94-R94) [[2]](diffhunk://#diff-e0209a3326dbc46514a7f7e75496fe5173eb9d9269eb7f7b714d961d414a2595L187-R187) [[3]](diffhunk://#diff-e0209a3326dbc46514a7f7e75496fe5173eb9d9269eb7f7b714d961d414a2595L220-R223) [[4]](diffhunk://#diff-e0209a3326dbc46514a7f7e75496fe5173eb9d9269eb7f7b714d961d414a2595R276-R281) [[5]](diffhunk://#diff-e0209a3326dbc46514a7f7e75496fe5173eb9d9269eb7f7b714d961d414a2595L331-L341)

**UI & Test Updates:**

* Updated UI texts and test assertions to use the new "Choose a cover image" phrasing instead of "Cover URL". (`app/src/androidTest/kotlin/com/misw4203/vinilos/app/CreateAlbumNavigationEspressoTest.kt`)

**Build & Configuration:**

* Added automatic Java toolchain download and the `foojay-resolver-convention` plugin to improve build reliability and environment setup. (`gradle.properties`, `settings.gradle.kts`) [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R2) [[2]](diffhunk://#diff-5625e3601fa0ad3a6a2824239e5a2fde71c149597d31394f9224a08c24be7b9dR1) [[3]](diffhunk://#diff-5625e3601fa0ad3a6a2824239e5a2fde71c149597d31394f9224a08c24be7b9dR10-R13)

Other minor changes include timestamp updates and whitespace cleanup. [[1]](diffhunk://#diff-48ade0dcc88e13ad2f209104182451574719123469c44aa4bb0558302d2ee7fbL7-R7) [[2]](diffhunk://#diff-e0209a3326dbc46514a7f7e75496fe5173eb9d9269eb7f7b714d961d414a2595L589-L590) [[3]](diffhunk://#diff-f0477c3f288d299091be4c997682ba28aced472401c91bb33a54db89b694b5cbL87-L89) [[4]](diffhunk://#diff-5625e3601fa0ad3a6a2824239e5a2fde71c149597d31394f9224a08c24be7b9dL24)