### PR TITLE
feat(HU08): add track to album via bottom dialog, Collector-only FAB

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -29,7 +29,33 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-1458929648">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-1088286143">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-759243807">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,8 +13,26 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="Tests in 'com.misw4203.vinilos.app'">
+      <SelectionState runConfigName="All Tests">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2026-05-10T00:25:21.655780Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=geh6eyof8tmvv485" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
+      </SelectionState>
+      <SelectionState runConfigName="Tests in 'com.misw4203.vinilos.feature.home.ui'">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2026-05-10T00:25:21.655780Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=geh6eyof8tmvv485" />
+            </handle>
+          </Target>
+        </DropdownSelection>
         <DialogSelection />
       </SelectionState>
     </selectionStates>

--- a/app/src/androidTest/kotlin/com/misw4203/vinilos/app/AddTrackEspressoTest.kt
+++ b/app/src/androidTest/kotlin/com/misw4203/vinilos/app/AddTrackEspressoTest.kt
@@ -1,0 +1,150 @@
+package com.misw4203.vinilos.app
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.misw4203.vinilos.feature.home.ui.ADD_TRACK_CONFIRM_TAG
+import com.misw4203.vinilos.feature.home.ui.ADD_TRACK_FAB_TAG
+import org.junit.Assume
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * End-to-end smoke tests for HU08 (Add Track to Album).
+ *
+ * - Verifies that the "Add Track" FAB is visible for Collector but not for Visitor.
+ * - Verifies that the AddTrack dialog opens when the FAB is clicked.
+ *
+ * Backend availability is not guaranteed; data-dependent steps are guarded with
+ * [Assume] so the suite stays green in offline environments.
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class AddTrackEspressoTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun visitor_doesNotSeeAddTrackFab_onAlbumDetail() {
+        navigateToAlbumDetailAs(role = "Visitor") ?: return
+
+        // The FAB must not be visible for Visitor.
+        val fabNodes = composeRule.onAllNodesWithTag(ADD_TRACK_FAB_TAG).fetchSemanticsNodes()
+        assertTrue("Visitor must not see Add Track FAB", fabNodes.isEmpty())
+    }
+
+    @Test
+    fun collector_seesAddTrackFab_andCanOpenDialog() {
+        navigateToAlbumDetailAs(role = "Collector") ?: return
+
+        // FAB is visible for Collector.
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ADD_TRACK_FAB_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(ADD_TRACK_FAB_TAG).assertIsDisplayed()
+
+        // Opening the dialog.
+        composeRule.onNodeWithTag(ADD_TRACK_FAB_TAG).performClick()
+        composeRule.waitForIdle()
+        Espresso.onIdle()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText("Add Track to Album").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithText("Add Track to Album").assertIsDisplayed()
+        composeRule.onNodeWithText("Search for a track...").assertIsDisplayed()
+        composeRule.onNodeWithTag(ADD_TRACK_CONFIRM_TAG).assertIsDisplayed()
+    }
+
+    @Test
+    fun collector_canDismissAddTrackDialog() {
+        navigateToAlbumDetailAs(role = "Collector") ?: return
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithTag(ADD_TRACK_FAB_TAG).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(ADD_TRACK_FAB_TAG).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+            composeRule.onAllNodesWithText("Add Track to Album").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeRule.onNodeWithText("Cancel").performClick()
+        composeRule.waitForIdle()
+        Espresso.onIdle()
+
+        // Dialog is dismissed — the title should be gone.
+        val dialogNodes = composeRule.onAllNodesWithText("Add Track to Album").fetchSemanticsNodes()
+        assertTrue("Dialog must be dismissed after Cancel", dialogNodes.isEmpty())
+    }
+
+    // -- helpers --------------------------------------------------------------
+
+    /**
+     * Navigates to auth as [role], lands on the catalog, and opens the first album.
+     * Returns null (and skips via [Assume]) if no albums are available.
+     */
+    private fun navigateToAlbumDetailAs(role: String): Unit? {
+        waitForText("Select Your Profile")
+        composeRule.onNodeWithText(role).performClick()
+        composeRule.waitForIdle()
+        continueFromAuthIfNeeded()
+        Espresso.onIdle()
+        waitForText("Vinilos")
+
+        // Navigate into an album — requires backend to have at least one album.
+        val featuredAvailable = waitForCondition(timeoutMillis = 10_000) {
+            composeRule.onAllNodesWithText("FEATURED RELEASE").fetchSemanticsNodes().isNotEmpty()
+        }
+        Assume.assumeTrue(
+            "Album catalog not reachable; HU08 Add Track E2E skipped.",
+            featuredAvailable,
+        )
+
+        composeRule.onNodeWithText("FEATURED RELEASE").performClick()
+        composeRule.waitForIdle()
+        Espresso.onIdle()
+
+        val detailAvailable = waitForCondition(timeoutMillis = 10_000) {
+            composeRule.onAllNodesWithText("About this release").fetchSemanticsNodes().isNotEmpty()
+        }
+        Assume.assumeTrue(
+            "Album detail not reachable; HU08 Add Track E2E skipped.",
+            detailAvailable,
+        )
+
+        return Unit
+    }
+
+    private fun waitForText(text: String) {
+        composeRule.waitUntil(timeoutMillis = 10_000) {
+            composeRule.onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun waitForCondition(timeoutMillis: Long, condition: () -> Boolean): Boolean =
+        runCatching { composeRule.waitUntil(timeoutMillis = timeoutMillis, condition = condition) }
+            .isSuccess
+
+    private fun continueFromAuthIfNeeded() {
+        val getStartedNodes = composeRule.onAllNodesWithText("Get Started").fetchSemanticsNodes()
+        if (getStartedNodes.isNotEmpty()) {
+            composeRule.onNodeWithText("Get Started").performClick()
+            composeRule.waitForIdle()
+        }
+    }
+
+    private fun assertTrue(message: String, condition: Boolean) {
+        if (!condition) throw AssertionError(message)
+    }
+}

--- a/app/src/main/kotlin/com/misw4203/vinilos/app/AppContainer.kt
+++ b/app/src/main/kotlin/com/misw4203/vinilos/app/AppContainer.kt
@@ -14,6 +14,7 @@ import com.misw4203.vinilos.feature.auth.ui.AuthViewModel
 import com.misw4203.vinilos.feature.home.data.repository.provideArtistsRepository
 import com.misw4203.vinilos.feature.home.data.repository.provideCollectorsRepository
 import com.misw4203.vinilos.feature.home.data.repository.provideHomeRepository
+import com.misw4203.vinilos.feature.home.domain.usecase.AddTrackUseCase
 import com.misw4203.vinilos.feature.home.domain.usecase.ObserveAlbumDetailUseCase
 import com.misw4203.vinilos.feature.home.domain.usecase.ObserveArtistDetailUseCase
 import com.misw4203.vinilos.feature.home.domain.usecase.ObserveArtistsUseCase
@@ -44,6 +45,7 @@ class AppContainer(context: Context) {
     private val observeHomeItemsUseCase = ObserveHomeItemsUseCase(homeRepository)
     private val observeAlbumDetailUseCase = ObserveAlbumDetailUseCase(homeRepository)
     private val createAlbumUseCase = CreateAlbumUseCase(homeRepository)
+    private val addTrackUseCase = AddTrackUseCase(homeRepository)
     private val uploadCoverUseCase = com.misw4203.vinilos.feature.home.domain.usecase.UploadCoverUseCase(homeRepository)
     private val observeArtistsUseCase = ObserveArtistsUseCase(artistsRepository)
     private val observeArtistDetailUseCase = ObserveArtistDetailUseCase(artistsRepository)
@@ -69,6 +71,8 @@ class AppContainer(context: Context) {
         AlbumDetailViewModel(
             albumId = albumId,
             observeAlbumDetailUseCase = observeAlbumDetailUseCase,
+            observeSessionUseCase = observeSessionUseCase,
+            addTrackUseCase = addTrackUseCase,
         )
     }
 

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/data/remote/HomeService.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/data/remote/HomeService.kt
@@ -8,4 +8,5 @@ interface HomeService {
     suspend fun getAlbum(id: String): AlbumDto?
     suspend fun createAlbum(album: AlbumDto): Boolean
     suspend fun uploadCover(contentResolver: ContentResolver, uriString: String): String?
+    suspend fun addTrack(albumId: String, name: String, duration: String): Boolean
 }

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/data/remote/HttpHomeService.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/data/remote/HttpHomeService.kt
@@ -137,11 +137,46 @@ class HttpHomeService(
         )
     }
 
+    override suspend fun addTrack(albumId: String, name: String, duration: String): Boolean {
+        val connection = openConnection("/albums/$albumId/tracks")
+        return try {
+            connection.requestMethod = "POST"
+            connection.doOutput = true
+            connection.setRequestProperty("Content-Type", "application/json; charset=UTF-8")
+            connection.connectTimeout = TIMEOUT_MILLIS
+            connection.readTimeout = TIMEOUT_MILLIS
+
+            val payload = JSONObject().apply {
+                put("name", name)
+                put("duration", duration)
+            }.toString()
+
+            connection.outputStream.use { os ->
+                os.write(payload.toByteArray(Charsets.UTF_8))
+                os.flush()
+            }
+
+            val responseCode = connection.responseCode
+            val isSuccess = responseCode in HTTP_SUCCESS_RANGE
+            if (!isSuccess) {
+                val errorBody = connection.errorStream?.bufferedReader()?.use { it.readText() } ?: "No error body"
+                Log.e(TAG, "POST /albums/$albumId/tracks error $responseCode: $errorBody")
+            }
+            isSuccess
+        } catch (e: Exception) {
+            Log.e(TAG, "POST /albums/$albumId/tracks exception: ${e.message}", e)
+            false
+        } finally {
+            connection.disconnect()
+        }
+    }
+
     private fun openConnection(path: String): HttpURLConnection {
         return (URL(baseUrl.trimEnd('/') + path).openConnection() as HttpURLConnection)
     }
 
     private companion object {
+        const val TAG = "HttpHomeService"
         const val TIMEOUT_MILLIS = 10_000
         val HTTP_SUCCESS_RANGE = 200..299
     }

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/data/repository/RemoteHomeRepository.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/data/repository/RemoteHomeRepository.kt
@@ -87,6 +87,16 @@ class RemoteHomeRepository(
         }
     }
 
+    override suspend fun addTrack(albumId: String, name: String, duration: String): Boolean {
+        return try {
+            withContext(ioDispatcher) {
+                service.addTrack(albumId, name, duration)
+            }
+        } catch (_: Exception) {
+            false
+        }
+    }
+
     private fun List<AlbumDto>.toHomeItems(): List<HomeItem> =
         mapIndexed { index, dto -> dto.toHomeItem(index) }
 }

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/domain/repository/HomeRepository.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/domain/repository/HomeRepository.kt
@@ -10,5 +10,6 @@ interface HomeRepository {
     fun observeItem(id: String): Flow<HomeItem?>
     suspend fun createAlbum(album: AlbumDto): Boolean
     suspend fun uploadCover(contentResolver: ContentResolver, uriString: String): String?
+    suspend fun addTrack(albumId: String, name: String, duration: String): Boolean
 }
 

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/domain/usecase/AddTrackUseCase.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/domain/usecase/AddTrackUseCase.kt
@@ -1,0 +1,8 @@
+package com.misw4203.vinilos.feature.home.domain.usecase
+
+import com.misw4203.vinilos.feature.home.domain.repository.HomeRepository
+
+class AddTrackUseCase(private val repository: HomeRepository) {
+    suspend operator fun invoke(albumId: String, name: String, duration: String): Boolean =
+        repository.addTrack(albumId, name, duration)
+}

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/AlbumDetailScreen.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/AlbumDetailScreen.kt
@@ -1,6 +1,8 @@
 package com.misw4203.vinilos.feature.home.ui
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,17 +17,28 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.LibraryAdd
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -33,9 +46,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.misw4203.vinilos.core.ui.components.VinilosTopBar
@@ -57,6 +75,28 @@ fun AlbumDetailScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val album = state.album
 
+    LaunchedEffect(Unit) {
+        viewModel.effects.collect { effect ->
+            when (effect) {
+                is AlbumDetailUiEffect.TrackAdded -> { /* track added — list will refresh on next open */ }
+            }
+        }
+    }
+
+    if (state.showAddTrackDialog) {
+        AddTrackDialog(
+            albumTitle = album?.title ?: "",
+            trackName = state.trackName,
+            trackDuration = state.trackDuration,
+            isAdding = state.isAddingTrack,
+            error = state.addTrackError,
+            onTrackNameChange = viewModel::onTrackNameChange,
+            onTrackDurationChange = viewModel::onTrackDurationChange,
+            onDismiss = viewModel::onDismissAddTrack,
+            onConfirm = viewModel::onConfirmAddTrack,
+        )
+    }
+
     androidx.compose.material3.Scaffold(
         modifier = modifier,
         containerColor = MaterialTheme.colorScheme.background,
@@ -66,6 +106,23 @@ fun AlbumDetailScreen(
                 onBackClick = onBack,
                 onSearchClick = { },
             )
+        },
+        floatingActionButton = {
+            if (state.canCreate) {
+                ExtendedFloatingActionButton(
+                    onClick = viewModel::onAddTrackClick,
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Add,
+                            contentDescription = null,
+                        )
+                    },
+                    text = { Text(text = "Add Track") },
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.testTag(ADD_TRACK_FAB_TAG),
+                )
+            }
         },
     ) { paddingValues ->
         if (state.isLoading) {
@@ -398,6 +455,231 @@ private fun DetailChip(text: String) {
         )
     }
 }
+
+@Composable
+internal fun AddTrackDialog(
+    albumTitle: String,
+    trackName: String,
+    trackDuration: String,
+    isAdding: Boolean,
+    error: String?,
+    onTrackNameChange: (String) -> Unit,
+    onTrackDurationChange: (String) -> Unit,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    Dialog(onDismissRequest = { if (!isAdding) onDismiss() }) {
+        Card(
+            shape = RoundedCornerShape(28.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+            ),
+            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // Icon header
+                Box(
+                    modifier = Modifier
+                        .size(56.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.LibraryAdd,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(28.dp),
+                    )
+                }
+
+                // Titles
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = "Add Track to Album",
+                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                        color = MaterialTheme.colorScheme.onBackground,
+                    )
+                    if (albumTitle.isNotBlank()) {
+                        Text(
+                            text = albumTitle,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                // Track name field
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = "SEARCH TRACKS",
+                        style = MaterialTheme.typography.labelMedium.copy(
+                            letterSpacing = 2.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        ),
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    TrackInputPill(
+                        value = trackName,
+                        onValueChange = onTrackNameChange,
+                        placeholder = "Search for a track...",
+                        leadingIcon = true,
+                        testTag = ADD_TRACK_NAME_TAG,
+                    )
+
+                    // Duration field
+                    Text(
+                        text = "DURATION",
+                        style = MaterialTheme.typography.labelMedium.copy(
+                            letterSpacing = 2.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        ),
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    TrackInputPill(
+                        value = trackDuration,
+                        onValueChange = onTrackDurationChange,
+                        placeholder = "e.g. 3:45",
+                        leadingIcon = false,
+                        testTag = ADD_TRACK_DURATION_TAG,
+                    )
+
+                    if (error != null) {
+                        Text(
+                            text = error,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+
+                // Action buttons
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    TextButton(
+                        onClick = onDismiss,
+                        enabled = !isAdding,
+                    ) {
+                        Text(
+                            text = "Cancel",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Button(
+                        onClick = onConfirm,
+                        enabled = !isAdding && trackName.isNotBlank(),
+                        shape = RoundedCornerShape(999.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary,
+                        ),
+                        modifier = Modifier.testTag(ADD_TRACK_CONFIRM_TAG),
+                    ) {
+                        if (isAdding) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.onPrimary,
+                            )
+                        } else {
+                            Text(text = "Add Track")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TrackInputPill(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    leadingIcon: Boolean,
+    testTag: String,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val containerColor = if (isFocused) {
+        MaterialTheme.colorScheme.surfaceBright
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerHigh
+    }
+    val iconColor = if (isFocused) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(50.dp),
+        shape = RoundedCornerShape(999.dp),
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (leadingIcon) {
+                androidx.compose.foundation.Image(
+                    imageVector = Icons.Outlined.Search,
+                    contentDescription = null,
+                    colorFilter = androidx.compose.ui.graphics.ColorFilter.tint(iconColor),
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+            BasicTextField(
+                value = value,
+                onValueChange = onValueChange,
+                singleLine = true,
+                interactionSource = interactionSource,
+                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                textStyle = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onSurface,
+                ),
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag(testTag),
+                decorationBox = { innerTextField ->
+                    if (value.isEmpty()) {
+                        Text(
+                            text = placeholder,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    innerTextField()
+                },
+            )
+        }
+    }
+}
+
+const val ADD_TRACK_FAB_TAG = "add_track_fab"
+const val ADD_TRACK_NAME_TAG = "add_track_name_field"
+const val ADD_TRACK_DURATION_TAG = "add_track_duration_field"
+const val ADD_TRACK_CONFIRM_TAG = "add_track_confirm_button"
 
 private fun formatReleaseDate(releaseDate: String?, fallbackYear: Int): String {
     if (releaseDate.isNullOrBlank()) {

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/AlbumDetailUiState.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/AlbumDetailUiState.kt
@@ -5,5 +5,14 @@ import com.misw4203.vinilos.feature.home.domain.model.HomeItem
 data class AlbumDetailUiState(
     val isLoading: Boolean = true,
     val album: HomeItem? = null,
+    val canCreate: Boolean = false,
+    val showAddTrackDialog: Boolean = false,
+    val isAddingTrack: Boolean = false,
+    val trackName: String = "",
+    val trackDuration: String = "",
+    val addTrackError: String? = null,
 )
 
+sealed interface AlbumDetailUiEffect {
+    data object TrackAdded : AlbumDetailUiEffect
+}

--- a/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/AlbumDetailViewModel.kt
+++ b/feature-home/src/main/kotlin/com/misw4203/vinilos/feature/home/ui/AlbumDetailViewModel.kt
@@ -2,28 +2,91 @@ package com.misw4203.vinilos.feature.home.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.misw4203.vinilos.core.utils.usecase.ObserveSessionUseCase
+import com.misw4203.vinilos.feature.home.domain.usecase.AddTrackUseCase
 import com.misw4203.vinilos.feature.home.domain.usecase.ObserveAlbumDetailUseCase
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 class AlbumDetailViewModel(
-    albumId: String,
+    private val albumId: String,
     observeAlbumDetailUseCase: ObserveAlbumDetailUseCase,
+    observeSessionUseCase: ObserveSessionUseCase,
+    private val addTrackUseCase: AddTrackUseCase,
 ) : ViewModel() {
 
-    val uiState: StateFlow<AlbumDetailUiState> = observeAlbumDetailUseCase(albumId)
-        .map { album ->
-            AlbumDetailUiState(
-                isLoading = false,
-                album = album,
-            )
-        }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = AlbumDetailUiState(),
+    private val _dialogState = MutableStateFlow(AddTrackDialogState())
+
+    val uiState: StateFlow<AlbumDetailUiState> = combine(
+        observeAlbumDetailUseCase(albumId),
+        observeSessionUseCase(),
+        _dialogState,
+    ) { album, session, dialog ->
+        AlbumDetailUiState(
+            isLoading = false,
+            album = album,
+            canCreate = session?.permissions?.canCreate == true,
+            showAddTrackDialog = dialog.show,
+            isAddingTrack = dialog.isAdding,
+            trackName = dialog.name,
+            trackDuration = dialog.duration,
+            addTrackError = dialog.error,
         )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = AlbumDetailUiState(),
+    )
+
+    private val _effects = MutableSharedFlow<AlbumDetailUiEffect>()
+    val effects = _effects.asSharedFlow()
+
+    fun onAddTrackClick() {
+        _dialogState.update { it.copy(show = true, name = "", duration = "", error = null) }
+    }
+
+    fun onDismissAddTrack() {
+        _dialogState.value = AddTrackDialogState()
+    }
+
+    fun onTrackNameChange(value: String) {
+        _dialogState.update { it.copy(name = value, error = null) }
+    }
+
+    fun onTrackDurationChange(value: String) {
+        _dialogState.update { it.copy(duration = value, error = null) }
+    }
+
+    fun onConfirmAddTrack() {
+        val s = _dialogState.value
+        if (s.name.isBlank()) {
+            _dialogState.update { it.copy(error = "Track name is required") }
+            return
+        }
+        viewModelScope.launch {
+            _dialogState.update { it.copy(isAdding = true, error = null) }
+            val ok = addTrackUseCase(albumId, s.name.trim(), s.duration.trim())
+            if (ok) {
+                _dialogState.value = AddTrackDialogState()
+                _effects.emit(AlbumDetailUiEffect.TrackAdded)
+            } else {
+                _dialogState.update { it.copy(isAdding = false, error = "Could not add track. Please try again.") }
+            }
+        }
+    }
 }
 
+private data class AddTrackDialogState(
+    val show: Boolean = false,
+    val isAdding: Boolean = false,
+    val name: String = "",
+    val duration: String = "",
+    val error: String? = null,
+)

--- a/feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/data/remote/HttpHomeServiceTest.kt
+++ b/feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/data/remote/HttpHomeServiceTest.kt
@@ -5,6 +5,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -169,5 +170,45 @@ class HttpHomeServiceTest {
 
         assertEquals(42L, album?.id)
         assertEquals("Alt Id Album", album?.name)
+    }
+
+    // -- addTrack --------------------------------------------------------
+
+    @Test
+    fun addTrack_returnsTrue_on201() = runTest {
+        server.enqueue(MockResponse().setResponseCode(201).setBody("{}"))
+
+        val result = service.addTrack(albumId = "5", name = "Decisiones", duration = "4:30")
+
+        assertTrue(result)
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/albums/5/tracks", request.path)
+        val body = request.body.readUtf8()
+        assertTrue(body.contains("\"name\""))
+        assertTrue(body.contains("Decisiones"))
+        assertTrue(body.contains("\"duration\""))
+        assertTrue(body.contains("4:30"))
+    }
+
+    @Test
+    fun addTrack_returnsTrue_on200() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+
+        assertTrue(service.addTrack("1", "Track A", "3:00"))
+    }
+
+    @Test
+    fun addTrack_returnsFalse_on400() = runTest {
+        server.enqueue(MockResponse().setResponseCode(400))
+
+        assertFalse(service.addTrack("1", "Bad Track", ""))
+    }
+
+    @Test
+    fun addTrack_returnsFalse_on500() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500))
+
+        assertFalse(service.addTrack("1", "Track", "1:00"))
     }
 }

--- a/feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/data/repository/RemoteHomeRepositoryTest.kt
+++ b/feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/data/repository/RemoteHomeRepositoryTest.kt
@@ -185,6 +185,7 @@ class RemoteHomeRepositoryTest {
         override suspend fun getAlbum(id: String): AlbumDto? = albumsById[id]
         override suspend fun createAlbum(album: AlbumDto): Boolean = true
         override suspend fun uploadCover(contentResolver: android.content.ContentResolver, uriString: String): String? = null
+        override suspend fun addTrack(albumId: String, name: String, duration: String): Boolean = true
     }
 
     private class FakeAlbumsLocalCache(

--- a/feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/domain/usecase/CreateAlbumUseCaseTest.kt
+++ b/feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/domain/usecase/CreateAlbumUseCaseTest.kt
@@ -65,6 +65,8 @@ class CreateAlbumUseCaseTest {
         }
 
         override suspend fun uploadCover(contentResolver: android.content.ContentResolver, uriString: String): String? = null
+
+        override suspend fun addTrack(albumId: String, name: String, duration: String): Boolean = true
     }
 }
 

--- a/feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/ui/AlbumDetailViewModelTest.kt
+++ b/feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/ui/AlbumDetailViewModelTest.kt
@@ -1,12 +1,19 @@
 package com.misw4203.vinilos.feature.home.ui
 
+import com.misw4203.vinilos.core.utils.model.RolePermissions
+import com.misw4203.vinilos.core.utils.model.UserRole
+import com.misw4203.vinilos.core.utils.model.UserSession
+import com.misw4203.vinilos.core.utils.repository.SessionRepository
+import com.misw4203.vinilos.core.utils.usecase.ObserveSessionUseCase
 import com.misw4203.vinilos.feature.home.domain.model.HomeItem
 import com.misw4203.vinilos.feature.home.domain.repository.HomeRepository
+import com.misw4203.vinilos.feature.home.domain.usecase.AddTrackUseCase
 import com.misw4203.vinilos.feature.home.domain.usecase.ObserveAlbumDetailUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
@@ -29,10 +36,11 @@ class AlbumDetailViewModelTest {
     @get:Rule
     val mainDispatcherRule: TestWatcher = AlbumDetailMainDispatcherRule()
 
+    // -- existing tests -------------------------------------------------------
+
     @Test
     fun initialState_isLoadingWithNoAlbum() {
-        val repository = FakeAlbumRepository(MutableStateFlow(null))
-        val viewModel = AlbumDetailViewModel("1", ObserveAlbumDetailUseCase(repository))
+        val viewModel = buildViewModel()
 
         val initial = viewModel.uiState.value
         assertTrue(initial.isLoading)
@@ -41,27 +49,24 @@ class AlbumDetailViewModelTest {
 
     @Test
     fun whenAlbumEmits_stateExposesAlbumAndStopsLoading() = runTest {
-        val flow = MutableStateFlow<HomeItem?>(null)
-        val repository = FakeAlbumRepository(flow)
-        val viewModel = AlbumDetailViewModel("42", ObserveAlbumDetailUseCase(repository))
+        val albumFlow = MutableStateFlow<HomeItem?>(null)
+        val viewModel = buildViewModel(albumFlow = albumFlow)
         val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
 
-        flow.value = sampleAlbum()
+        albumFlow.value = sampleAlbum()
         advanceUntilIdle()
 
         val state = viewModel.uiState.value
         assertFalse(state.isLoading)
         assertEquals("42", state.album?.id)
         assertEquals("Sample", state.album?.title)
-        assertEquals("42", repository.requestedIds.last())
 
         collectJob.cancel()
     }
 
     @Test
     fun whenAlbumIsMissing_stateExposesNullAlbum() = runTest {
-        val repository = FakeAlbumRepository(MutableStateFlow<HomeItem?>(null))
-        val viewModel = AlbumDetailViewModel("missing", ObserveAlbumDetailUseCase(repository))
+        val viewModel = buildViewModel()
         val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
 
         advanceUntilIdle()
@@ -71,6 +76,146 @@ class AlbumDetailViewModelTest {
         assertNull(state.album)
 
         collectJob.cancel()
+    }
+
+    // -- permissions ----------------------------------------------------------
+
+    @Test
+    fun canCreate_isFalse_forVisitorSession() = runTest {
+        val viewModel = buildViewModel(role = UserRole.VISITOR)
+        val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.canCreate)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun canCreate_isTrue_forCollectorSession() = runTest {
+        val viewModel = buildViewModel(role = UserRole.COLLECTOR)
+        val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.canCreate)
+
+        collectJob.cancel()
+    }
+
+    // -- add track dialog state -----------------------------------------------
+
+    @Test
+    fun onAddTrackClick_opensDialog() = runTest {
+        val viewModel = buildViewModel()
+        val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
+        advanceUntilIdle()
+
+        viewModel.onAddTrackClick()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.showAddTrackDialog)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun onDismissAddTrack_closesDialog() = runTest {
+        val viewModel = buildViewModel()
+        val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
+        advanceUntilIdle()
+
+        viewModel.onAddTrackClick()
+        advanceUntilIdle()
+        viewModel.onDismissAddTrack()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.showAddTrackDialog)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun onTrackNameChange_updatesState() = runTest {
+        val viewModel = buildViewModel()
+        val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
+        advanceUntilIdle()
+
+        viewModel.onAddTrackClick()
+        viewModel.onTrackNameChange("Decisiones")
+        advanceUntilIdle()
+
+        assertEquals("Decisiones", viewModel.uiState.value.trackName)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun onConfirmAddTrack_withBlankName_setsError() = runTest {
+        val viewModel = buildViewModel()
+        val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
+        advanceUntilIdle()
+
+        viewModel.onAddTrackClick()
+        viewModel.onConfirmAddTrack()
+        advanceUntilIdle()
+
+        assertEquals("Track name is required", viewModel.uiState.value.addTrackError)
+        assertTrue(viewModel.uiState.value.showAddTrackDialog)
+        collectJob.cancel()
+    }
+
+    @Test
+    fun onConfirmAddTrack_onSuccess_closesDialogAndEmitsEffect() = runTest {
+        val viewModel = buildViewModel(addTrackResult = true)
+        val effects = mutableListOf<AlbumDetailUiEffect>()
+        val effectJob = backgroundScope.launch { viewModel.effects.collect { effects += it } }
+        val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
+        advanceUntilIdle()
+
+        viewModel.onAddTrackClick()
+        viewModel.onTrackNameChange("Decisiones")
+        viewModel.onTrackDurationChange("4:30")
+        viewModel.onConfirmAddTrack()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.uiState.value.showAddTrackDialog)
+        assertEquals(1, effects.size)
+        assertEquals(AlbumDetailUiEffect.TrackAdded, effects[0])
+
+        collectJob.cancel()
+        effectJob.cancel()
+    }
+
+    @Test
+    fun onConfirmAddTrack_onFailure_showsError() = runTest {
+        val viewModel = buildViewModel(addTrackResult = false)
+        val collectJob = backgroundScope.launch { viewModel.uiState.collect { } }
+        advanceUntilIdle()
+
+        viewModel.onAddTrackClick()
+        viewModel.onTrackNameChange("Decisiones")
+        viewModel.onConfirmAddTrack()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.showAddTrackDialog)
+        assertFalse(viewModel.uiState.value.isAddingTrack)
+        assertTrue(viewModel.uiState.value.addTrackError?.isNotBlank() == true)
+
+        collectJob.cancel()
+    }
+
+    // -- helpers --------------------------------------------------------------
+
+    private fun buildViewModel(
+        albumFlow: MutableStateFlow<HomeItem?> = MutableStateFlow(null),
+        role: UserRole = UserRole.VISITOR,
+        addTrackResult: Boolean = true,
+    ): AlbumDetailViewModel {
+        val repository = FakeAlbumRepository(albumFlow, addTrackResult = addTrackResult)
+        val sessionRepository = AlbumDetailFakeSessionRepository(role)
+        return AlbumDetailViewModel(
+            albumId = "42",
+            observeAlbumDetailUseCase = ObserveAlbumDetailUseCase(repository),
+            observeSessionUseCase = ObserveSessionUseCase(sessionRepository),
+            addTrackUseCase = AddTrackUseCase(repository),
+        )
     }
 
     private fun sampleAlbum(): HomeItem = HomeItem(
@@ -97,6 +242,7 @@ private class AlbumDetailMainDispatcherRule(
 
 private class FakeAlbumRepository(
     private val flow: MutableStateFlow<HomeItem?>,
+    private val addTrackResult: Boolean = true,
 ) : HomeRepository {
     val requestedIds = mutableListOf<String>()
 
@@ -110,4 +256,19 @@ private class FakeAlbumRepository(
     override suspend fun createAlbum(album: com.misw4203.vinilos.feature.home.data.remote.dto.AlbumDto): Boolean = true
 
     override suspend fun uploadCover(contentResolver: android.content.ContentResolver, uriString: String): String? = null
+
+    override suspend fun addTrack(albumId: String, name: String, duration: String): Boolean = addTrackResult
+}
+
+private class AlbumDetailFakeSessionRepository(private val role: UserRole) : SessionRepository {
+    private val permissions = when (role) {
+        UserRole.COLLECTOR -> RolePermissions(canCreate = true, canEdit = true, canDelete = true)
+        UserRole.VISITOR -> RolePermissions()
+    }
+    private val session = UserSession(role = role, permissions = permissions)
+    private val flow = MutableStateFlow<UserSession?>(session)
+
+    override fun observeSession(): Flow<UserSession?> = flow
+    override suspend fun saveRole(role: UserRole) { }
+    override suspend fun clearSession() { flow.value = null }
 }

--- a/feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/ui/HomeViewModelTest.kt
+++ b/feature-home/src/test/kotlin/com/misw4203/vinilos/feature/home/ui/HomeViewModelTest.kt
@@ -188,5 +188,7 @@ private class FakeHomeRepository(
     override suspend fun createAlbum(album: com.misw4203.vinilos.feature.home.data.remote.dto.AlbumDto): Boolean = true
 
     override suspend fun uploadCover(contentResolver: android.content.ContentResolver, uriString: String): String? = null
+
+    override suspend fun addTrack(albumId: String, name: String, duration: String): Boolean = true
 }
 


### PR DESCRIPTION
Data layer:
- HomeService + HttpHomeService — addTrack(albumId, name, duration) via POST /albums/:albumId/tracks with JSON body
- HomeRepository + RemoteHomeRepository — delegation with withContext(ioDispatcher)

Domain: AddTrackUseCase

UI:
- AlbumDetailUiState — adds canCreate, showAddTrackDialog, isAddingTrack, trackName, trackDuration, addTrackError + AlbumDetailUiEffect.TrackAdded sealed interface
- AlbumDetailViewModel — refactored to combine(album, session, dialog) flows; derives canCreate from ObserveSessionUseCase; add track handlers with blank-name validation and error state
- AlbumDetailScreen — ExtendedFloatingActionButton (visible only when canCreate) + AddTrackDialog composable matching mockup: circular LibraryAdd icon, album name subtitle, SEARCH TRACKS pill input, DURATION field, Cancel / Add Track buttons with loading spinner

DI: AppContainer wires AddTrackUseCase + ObserveSessionUseCase into
    albumDetailViewModelFactory

Tests:
- HttpHomeServiceTest — 4 MockWebServer tests for addTrack (201, 200, 400, 500); verifies POST path and JSON body
- AlbumDetailViewModelTest — 9 unit tests covering initial state, Visitor/Collector canCreate, dialog open/close, blank-name validation, success → closes dialog + emits effect, failure → shows error
- AddTrackEspressoTest — 3 E2E tests: Visitor has no FAB, Collector sees FAB and opens dialog, Collector can cancel dialog
- Updated FakeHomeService/FakeHomeRepository in all affected test files